### PR TITLE
Changes for Deployment

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -46,7 +46,7 @@
             "last 1 safari version"
         ]
     },
-    "proxy": "http://0.0.0.0:5000",
+    "proxy": "http://0.0.0.0:8080",
     "devDependencies": {
         "node-sass": "^4.14.1"
     }

--- a/server/server.js
+++ b/server/server.js
@@ -26,6 +26,8 @@ app.use('/api/topic', require('./routes/api/topic'));
 app.use('/api/comment', require('./routes/api/comment'));
 app.use('/api/test', require('./routes/api/test'));
 
-const PORT = process.env.PORT || 5000;
+app.use(express.static('build'));
+
+const PORT = process.env.PORT || 8080;
 
 app.listen(PORT, '0.0.0.0', () => console.log(`Server started on port ${PORT}`));


### PR DESCRIPTION
1. Port 5000 doesn't work on mac (tested on m2)
2. Serve static build folder if available (will be used in production). Won't do any harm in local

The project doesn't work on Node 18 anymore (the current latest version). We ideally need to use v14, but faced some issue with v14 so managed to run with v16 by not using node-sass package.

P.S. @gsc2001 The instructions you added in readme file to run the project are wrong 😂 